### PR TITLE
Fix CryptoRandom range

### DIFF
--- a/MatrixRain/CryptoRandom.cs
+++ b/MatrixRain/CryptoRandom.cs
@@ -57,10 +57,10 @@ namespace MatrixRain
 		 * <param name="minValue">The inclusive lower bound of the random number returned.</param>
 		 * <param name="maxValue">The exclusive upper bound of the random number returned. maxValue must be greater than or equal to minValue.</param>
 		 */
-		public int Next(int minPValue, int maxPValue)
-		{
-			return (int)Math.Round(NextDouble() * (maxPValue - minPValue - 1)) + minPValue;
-		}
+                public int Next(int minPValue, int maxPValue)
+                {
+                        return (int)(NextDouble() * (maxPValue - minPValue)) + minPValue;
+                }
 		/**
 		 * <summary>
 		 * Returns a nonnegative random number
@@ -75,7 +75,7 @@ namespace MatrixRain
 		 * <summary>
 		 * Returns a nonnegative random number less than the specified maximum
 		 * </summary>
-		 * <param name="maxValue">The inclusive upper bound of the random number returned. maxValue must be greater than or equal 0</param>
+                 * <param name="maxValue">The exclusive upper bound of the random number returned. maxValue must be greater than or equal 0</param>
 		 */
 		public int Next(int maxValue)
 		{


### PR DESCRIPTION
## Summary
- fix `CryptoRandom.Next(min, max)` math
- clarify parameter docs

## Testing
- `dotnet build MatrixRainWpfApp.sln` *(fails: reference assemblies for .NETFramework,Version=v4.5.2 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffcaa449c832da1882147a224d4b7